### PR TITLE
Fix category tags wrap

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,6 +152,7 @@ textarea:focus {
 	padding: 0;
 	display: flex;
 	gap: .5rem;
+	flex-wrap: wrap;
 }
 .category,
 .tag,


### PR DESCRIPTION
This change fixes a bug that occured on post cards if category tags were wider than the available space:

![image](https://user-images.githubusercontent.com/5441654/168160828-2497eee0-bb38-4f90-ba97-f1c7be1ea687.png)
