### PR TITLE
Don't unnecessarily enlarge images

### DIFF
--- a/style.css
+++ b/style.css
@@ -500,9 +500,10 @@ main.post .content h2 {
 }
 main.post .content figure {
 	margin: 1rem 0;
+	text-align: center;
 }
 main.post .content figure img {
-	width: 100%;
+	max-width: 100%;
 }
 main.post .content figure figcaption {
 	text-align: center;


### PR DESCRIPTION
Wordpress resizes images to some specific sizes the theme can set. However, the images may also be smaller than any of these sizes. We currently scale up all images to full article width client side. I think we should just display them in their original resolution if they are smaller.