### PR TITLE
Handle sticky posts

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,13 +15,14 @@
 <main>
 	<section class="featured">
 	<?php 
-		$latest_posts = get_posts( array( 'numberposts' => 1 ) );
+		$sticky = get_option( 'sticky_posts' );
+		$latest_posts = get_posts( array( 'numberposts' => 1, 'include' => $sticky ) );
 		$post = count( $latest_posts ) > 0 ? $latest_posts[0] : null;
 	?>
 	<?php if ( $post ) : ?>
 		<article>
 			<div class="content">
-				<span class="category"><?php _e( 'Latest Post', 'thunderblog' ); ?></span>
+				<span class="category"><?php _e( isset( $sticky[0] ) ? 'Featured Post' : 'Latest Post', 'thunderblog' ); ?></span>
 				<a class="title" href="<?php the_permalink( $post ); ?>">
 					<h1><?php echo $post->post_title; ?></h1>
 				</a>

--- a/parts/post-meta.php
+++ b/parts/post-meta.php
@@ -20,6 +20,7 @@
 		</svg>
 		<?php echo get_the_date(); ?>
 	</time>
+	<?php if (array_key_exists('author', $args)): ?>
 	<a class="author" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID', $args['author'] ) ); ?>">
 		<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-s" viewBox="0 0 24 24">
 			<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -28,6 +29,7 @@
 		</svg>
 		<?php echo get_the_author_meta( 'display_name', $args['author'] ); ?>
 	</a>
+	<?php endif; ?>
 	<a class="responses" href="<?php echo rtrim( the_permalink(), '/' ); ?>#c">
 		<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-s" viewBox="0 0 24 24">
 			<path stroke="none" d="M0 0h24v24H0z" fill="none"/>


### PR DESCRIPTION
This change features the latest sticky post on top of the landing page (labeled 'featured'). If no sticky post exists, the latest post is shown (labeled 'latest').

It now also handles posts without author.