### PR TITLE
Fix floating image margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -525,6 +525,17 @@ main.post .content figure img {
 main.post .content figure figcaption {
 	text-align: center;
 }
+main.post .content figure.alignright,
+main.post .content figure.alignleft {
+	margin-top: 0;
+	margin-bottom: .5rem;
+}
+main.post .content figure.alignleft {
+	margin-right: 1rem;
+}
+main.post .content figure.alignright {
+	margin-left: 1rem;
+}
 main.post .tags {
 	display: flex;
 	gap: .5rem;


### PR DESCRIPTION
This change sets a right/left margin for left/right aligned images and makes images position appear more conveniently in text.

![image](https://user-images.githubusercontent.com/5441654/185611960-9c4d05c3-eb88-474b-bb69-f17899214be7.png)

Implements #22 