### PR TITLE
Load Thunderblog's themes and scripts only when it's time to do so.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -128,9 +128,11 @@ function thunderblog_customize_register ( $wp_customize ) {
 }
 add_action( 'customize_register', 'thunderblog_customize_register' );
 
-// load styles
-wp_enqueue_style( 'normalize', get_template_directory_uri() . '/assets/normalize.css' );
-wp_enqueue_style( 'style', get_stylesheet_uri() );
+add_action( 'wp_enqueue_scripts', function () {
+    // load styles
+    wp_enqueue_style( 'normalize', get_template_directory_uri() . '/assets/normalize.css' );
+    wp_enqueue_style( 'style', get_stylesheet_uri() );
 
-// load scripts
-wp_enqueue_script( 'script', get_template_directory_uri() . '/assets/main.js', [], 1.0, true );
+    // load scripts
+    wp_enqueue_script( 'script', get_template_directory_uri() . '/assets/main.js', [], 1.0, true );
+});


### PR DESCRIPTION
This should prevent the theme's style from bleeding into the admin back-end. As well as get rid of any warning messages with debug enabled. (On local instances.)

Tested on my local docker instance. 

Notices:
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/208732103-c1a11963-6ac4-4d69-b2aa-ee55a1df9cc6.png">

Admin Theme Bleeding:
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/208732176-cc97dd01-18b3-4557-ba5a-2f200e2965ae.png">

After:
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/208732266-40533723-529c-4e3c-abc6-295661d25093.png">

Search functionality (javascript) still works:
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/97147377/208732878-2381c7d6-9617-4a50-a7a3-466380249833.png">

And so does the menu bar:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/97147377/208733329-05726db0-cf59-4f10-b58e-ce7296fa8e8d.png">

(I don't have any menu items set-up.)

Tagging @devmount as he's probably the only other WordPress knowledgeable person who's worked on this project. 😄 
