### PR TITLE
Add featured image to rss feed

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -147,15 +147,34 @@ function thunderblog_add_featured_image_to_feed( string $text ): string {
 	return "<p>{$featured_image}</p>{$text}";
 }
 
+/**
+ * Echo's out a link entry containing the posts featured image, and caption if available.
+ * @return void
+ */
+function thunderblog_output_featured_image_as_link() {
+	global $post;
+
+	// No featured image? Skip!
+	if ( ! has_post_thumbnail( $post ) ) {
+		return;
+	}
+
+	$featured_image   = get_the_post_thumbnail_url( $post );
+	$featured_caption = get_the_post_thumbnail_caption( $post ) ?? $post->post_title;
+
+	echo "<link rel='thumbnail' href='{$featured_image}' title='{$featured_caption}' />";
+}
+
 add_action( 'customize_register', 'thunderblog_customize_register' );
 
-add_filter( 'the_content_feed', 'thunderblog_add_featured_image_to_feed');
+add_filter( 'the_content_feed', 'thunderblog_add_featured_image_to_feed' );
+add_filter( 'atom_entry', 'thunderblog_output_featured_image_as_link' );
 
 add_action( 'wp_enqueue_scripts', function () {
-    // load styles
-    wp_enqueue_style( 'normalize', get_template_directory_uri() . '/assets/normalize.css' );
-    wp_enqueue_style( 'style', get_stylesheet_uri() );
+	// load styles
+	wp_enqueue_style( 'normalize', get_template_directory_uri() . '/assets/normalize.css' );
+	wp_enqueue_style( 'style', get_stylesheet_uri() );
 
-    // load scripts
-    wp_enqueue_script( 'script', get_template_directory_uri() . '/assets/main.js', [], 1.0, true );
-});
+	// load scripts
+	wp_enqueue_script( 'script', get_template_directory_uri() . '/assets/main.js', [], 1.0, true );
+} );

--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,30 @@ function thunderblog_customize_register ( $wp_customize ) {
 		)
 	);
 }
+
+/**
+ * Adds the featured image (if any) to the (rss/atom/whatever) feed.
+ *
+ * @param string $text
+ *
+ * @return string
+ */
+function thunderblog_add_featured_image_to_feed( string $text ): string {
+	global $post;
+
+	// No featured image? Skip!
+	if ( ! has_post_thumbnail( $post ) ) {
+		return $text;
+	}
+
+	$featured_image = get_the_post_thumbnail( $post, [ 640, 360 ] );
+
+	return "<p>{$featured_image}</p>{$text}";
+}
+
 add_action( 'customize_register', 'thunderblog_customize_register' );
+
+add_filter( 'the_content_feed', 'thunderblog_add_featured_image_to_feed');
 
 // load styles
 wp_enqueue_style( 'normalize', get_template_directory_uri() . '/assets/normalize.css' );


### PR DESCRIPTION
Resolves #35 

Preview
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/97147377/208756525-0cd02e53-a085-4947-815f-59ee87e755ca.png">

I'm not sure if we want to adjust the presentation. It's currently not centred, and for readability purposes, I've restricted the size to 640x360 Based on the ticket description, we'll be showing this on thunderbird.net?  


I've attached the generated rss feed:
[zOJWLedH.rss.zip](https://github.com/thundernest/thunderblog/files/10272074/zOJWLedH.rss.zip)

I've also added some comments to help you follow along in-case you don't know WordPress development. 😄 
