### PR TITLE
Pass through the authour's ID as a template argument.

### DIFF
--- a/single.php
+++ b/single.php
@@ -25,7 +25,7 @@
 			<section class="content">
 				<?php the_category(); ?>
 				<?php the_title( '<h1>', '</h1>' ); ?>
-				<?php get_template_part('parts/post-meta'); ?>
+				<?php get_template_part('parts/post-meta', null, ['author' => get_the_author_meta('ID')]); ?>
 				<?php the_content(); ?>
 				<?php get_template_part('parts/post-tags'); ?>
 			</section>


### PR DESCRIPTION
Resolves #39 

<img width="670" alt="image" src="https://user-images.githubusercontent.com/97147377/217879353-a88d8bc0-38ad-4bf1-bc40-2752338cce48.png">

I was going to change the post-meta to use `get_the_author()`, but wasn't sure if this was going to break some work-around, so simply passed it in. 