### PR TITLE
Don't stretch featured image

### DIFF
--- a/style.css
+++ b/style.css
@@ -403,7 +403,7 @@ main > .featured article {
 main > .featured img {
 	max-height: calc(var(--featured-height) - 6rem);
 	width: 100%;
-	object-fit: cover;
+	object-fit: contain;
 }
 main > .featured article .category {
 	background: white;

--- a/style.css
+++ b/style.css
@@ -403,6 +403,7 @@ main > .featured article {
 main > .featured img {
 	max-height: calc(var(--featured-height) - 6rem);
 	width: 100%;
+	object-fit: cover;
 }
 main > .featured article .category {
 	background: white;


### PR DESCRIPTION
![Screenshot 2023-03-22 at 10-15-06 The Thunderbird Blog](https://user-images.githubusercontent.com/640949/226855888-d6708bbf-ce49-4b30-9211-fa99b66c23ff.png)

Alternatively this should be set to `contain`, but  `cover` matches what we do below.